### PR TITLE
fix: distribute src allowing sourcemaps to be built

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "url": "git+https://github.com/unbounce/parse-aws-arn.ts"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/**/*"
   ],
   "author": "Unbounce",
   "license": "MIT",


### PR DESCRIPTION
`source-map-loader` currently fails with:

```
WARNING in ./node_modules/@unbounce/parse-aws-arn/dist/index.js
[1] Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
[1] Failed to parse source map from '/.../node_modules/@unbounce/parse-aws-arn/src/index.ts' file: Error: ENOENT: no such file or directory, open '/.../node_modules/@unbounce/parse-aws-arn/src/index.ts'
```

This is easily remedied by also distributing the src in the package, allowing source maps to be built.